### PR TITLE
Run Docker build on commit to any branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build and push to production
+name: Deploy GitHub Pages
 on:
   release:
     types: [published]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
-name: Build and publish Docker image
+name: Docker Build
 on:
   push:
     branches:
-      - main
+      - '**'
     tags:
       - 'v*.*.*'
   release:
@@ -45,7 +45,7 @@ jobs:
           build-args: |
             version=${{ github.dev }}
             revision=${{ github.sha }}
-          tags: ghcr.io/${{ env.REPO }}:${{ github.sha }},ghcr.io/${{ env.REPO }}:dev
+          tags: ghcr.io/${{ env.REPO }}:${{ github.sha }},ghcr.io/${{ env.REPO }}:${{ github.ref_name }}
         if: ${{ github.ref_type == 'branch' }}
 
       # Only triggered by commits to tags

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ I've used this repository as a good excuse to dip my feet into CI/CD pipelines. 
 - Every Pull Request will be published to a staging website via Cloudflare Pages (please see each individual PR for the URL)
 - New releases will trigger a Docker image to be published to `latest`
 - A Docker image is built for every tag with that tag's name
-- Every push to the `main` branch will have a Docker image generated, using that commit's hash as the tag
+- Every push will have a Docker image generated, using that commit's hash as the tag
+- Each branch will have a Docker image with the tag equal to the branch name, using the latest commit to that branch
 - Dependabot will watch for potential dependency updates and automatically make Pull Requests when updates are found
 - Dependabot will report potential security vulnerabilities in dependencies to contributors


### PR DESCRIPTION
This PR will update the Docker GitHub Workflow so that it will make an extra build for each branch, where the image's tag will be equal to the branch name.

For commit's to the `main` branch, the image tag will now be `main` instead of `dev` as it was previously.

Passing the Docker build stage will now be required in order for a PR to be merged into the main branch.