### PR TITLE
I'm a Teapot page

### DIFF
--- a/src/lib/components/footer.svelte
+++ b/src/lib/components/footer.svelte
@@ -2,7 +2,7 @@
     import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
     import { faGithub } from '@fortawesome/free-brands-svg-icons';
     import {
-        faCopyright,
+        faCopyright, faMugHot,
         faRobot,
         faSitemap
     } from '@fortawesome/free-solid-svg-icons';
@@ -33,6 +33,10 @@
 
             <a class="hover:text-slate-400" href="/copyright" aria-label="Copyright & Attributions">
                 <FontAwesomeIcon icon={faCopyright} />
+            </a>
+
+            <a class="hover:text-slate-400" href="/teapot" aria-label="I'm a Teapot">
+                <FontAwesomeIcon icon={faMugHot} />
             </a>
         </p>
     </div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -7,40 +7,49 @@
 
 	const errors = {
 		400: { // Bad Request
-            msg: "You've sent an invalid request. What do you expect me to do with that?",
-            img: "/images/facepalm.png"
+			title: "PEBCAK Error",
+            message: "You've sent an invalid request. What do you expect me to do with that?",
+            emote: "/images/facepalm.png"
         },
 		401: { // Unauthorized
-            msg: "Halt! You got a license for that? You need to authenticate before I can let you do that.",
-            img: "/images/thinking.png"
+			title: "Halt! You got a license for that?",
+            message: "You need to authenticate before you can access this page.",
+            emote: "/images/thinking.png"
         },
         403: { // Forbidden
-			msg: "Sorry pal, looks like you can't access that content.",
-            img: "/images/facepalm.png"
+			title: "Missing Permissions",
+            message: "Sorry pal, looks like you can't access that content.",
+            emote: "/images/facepalm.png"
         },
 		404: { // Not Found
-			msg: "Looks like the page you've requested doesn't exist.",
-            img: "/images/thinking.png"
+			title: "Page Not Found",
+            message: "Looks like the page you've requested doesn't exist.",
+            emote: "/images/thinking.png"
         },
         418: { // I'm a Teapot
-			msg: "I'm a little teapot, short and stout. Here is my handle, here is my spout. When I get all steamed up, hear me shout 'Tip me over and pour me out!'",
-            img: "/images/tea.png"
+			title: "Woah! Crazy Easter Egg!",
+            message: "I'm a little teapot, short and stout. Here is my handle, here is my spout. When I get all steamed up, hear me shout 'Tip me over and pour me out!'",
+            emote: "/images/tea.png"
         },
         429: { // Too Many Requests
-			msg: "Stop, you've violated the ratelimit policy! Pay the Court a fine or serve your sentence!",
-            img: "/images/anger.png",
+			title: "You've Been Ratelimited!",
+            message: "Stop, you've violated the ratelimit policy! Pay the Court a fine or serve your sentence!",
+            emote: "/images/anger.png",
         },
         451: { // Unavailable for Legal Reasons
-			msg: "Move along, move along, nothing to see here. Please allow this button to guide you back home.",
-            img: "/images/thinking.png"
+			title: "For Legal Reasons this Content is Unavailable",
+            message: "Move along, move along, nothing to see here. Please allow this button to guide you back home.",
+            emote: "/images/thinking.png"
         },
         500: { // Internal Server Error
-			msg: "Something's broken. Very broken.",
-            img: "/images/facepalm.png"
+			title: "Stop, hammer time!",
+            message: "Something's broken. Very broken. An error like this shouldn't happen, please report this as a bug.",
+            emote: "/images/facepalm.png"
         },
         501: { // Not Implemented
-            msg: "Sorry, looks like that content isn't available yet. Check again later.",
-            img: "/images/sad.png"
+			title: "Under Construction",
+            message: "Sorry, looks like that content isn't available yet. Check again later.",
+            emote: "/images/sad.png"
         }
     };
 </script>
@@ -52,13 +61,13 @@
 <div class="min-h-screen p-8 lg:px-48 text-center flex flex-col justify-center">
     <div class="grid lg:grid-cols-3 gap-16 items-center">
         <div class="rounded-full mx-auto max-lg:w-3/4 bg-slate-800 border-10  border-slate-600">
-            <img class="rounded-b-full" src={errors[page.status].img} alt="Decorative emoji in Jack's likeness" />
+            <img class="rounded-b-full" src={errors[page.status].emote} alt="Decorative emoji in Jack's likeness" />
         </div>
 
         <div class="lg:col-span-2 flex flex-col gap-8">
             <h1 class="text-8xl font-bold">{page.status}</h1>
-            <h2 class="text-4xl font-bold">Well, this is awkward...</h2>
-            <p class="text-xl">{errors[page.status].msg}</p>
+            <h2 class="text-4xl font-bold">{errors[page.status].title}</h2>
+            <p class="text-xl">{errors[page.status].message}</p>
 
             <div class="flex flex-col lg:flex-row gap-8 justify-center">
                 <button>

--- a/src/routes/teapot/+page.ts
+++ b/src/routes/teapot/+page.ts
@@ -1,0 +1,5 @@
+import { error } from '@sveltejs/kit';
+
+export async function load() {
+    error(418);
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,7 +9,17 @@ export default {
             fallback: '404.html',
             precompress: false,
             strict: true
-        })
+        }),
+        prerender: {
+            handleHttpError: ({ status, message }) => {
+                // Ignore 418 errors encountered when building - these are always intentional
+                if (status === 418) {
+                    return;
+                }
+
+                throw new Error(message);
+            }
+        }
     },
     extensions: ['.svelte', '.svx', '.md'],
     preprocess: [mdsvex({ extensions: ['.svx', '.md'] })]


### PR DESCRIPTION
I always like to add the 418 I'm a teapot easter egg into my websites/APIs. I'm surprised it's taken this long tbh.

All this does is create a route that immediately causes a 418 error, thus reaching the normal error handling that's been configured to support 418. The code for error handling has been slightly refactored to rename some variables and also allow the subtitle to be changed depending on the error code received - the previous one didn't make sense for all errors.