### PR TITLE
Refactor error page props into a dedicated TS file

### DIFF
--- a/src/lib/content/index.ts
+++ b/src/lib/content/index.ts
@@ -1,5 +1,3 @@
-import type { File } from '$lib/types';
-
 export async function readFiles(paths: Record<string, File>): Promise<File[]> {
     const objs: File[] = [];
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,76 @@
+class ErrorPageProps {
+    title: string;
+    message: string;
+    emote: string;
+    bugBtn: boolean;
+
+    constructor(title: string, message: string, emote: string, bugBtn: boolean = false) {
+        this.title = title;
+        this.message = message;
+        this.emote = emote;
+        this.bugBtn = bugBtn;
+    }
+}
+
+const defaultPage: ErrorPageProps = new ErrorPageProps(
+    'Well this is awkward...',
+    'An unrecognised error has occurred. Please file a bug report.',
+    '/images/thinking.png',
+    true
+);
+
+export function getErrorPageProps(code: number): ErrorPageProps {
+    return (
+        {
+            400: new ErrorPageProps(
+                'Well this is awkward...',
+                'An unrecognised error has occurred. Please file a bug report.',
+                '/images/thinking.png'
+            ),
+            401: new ErrorPageProps(
+                'Halt! You got a license for that?',
+                'You need to authenticate before you can access this page.',
+                '/images/thinking.png',
+                true
+            ),
+            403: new ErrorPageProps(
+                'Missing Permissions',
+                "Sorry pal, looks like you can't access that content.",
+                '/images/facepalm.png',
+                true
+            ),
+            404: new ErrorPageProps(
+                'Page Not Found',
+                "Looks like the page you've requested doesn't exist.",
+                '/images/thinking.png',
+                true
+            ),
+            418: new ErrorPageProps(
+                'Woah! Crazy Easter Egg!',
+                "I'm a little teapot, short and stout. Here is my handle, here is my spout. When I get all steamed up, hear me shout 'Tip me over and pour me out!'",
+                '/images/tea.png'
+            ),
+            429: new ErrorPageProps(
+                "You've Been Ratelimited!",
+                "Stop, you've violated the ratelimit policy! Pay the Court a fine or serve your sentence!",
+                '/images/anger.png'
+            ),
+            451: new ErrorPageProps(
+                'For Legal Reasons this Content is Unavailable',
+                'Move along, move along, nothing to see here. Please allow this button to guide you back home.',
+                '/images/thinking.png'
+            ),
+            500: new ErrorPageProps(
+                'Stop, hammer time!',
+                "Something's broken. Very broken. An error like this shouldn't happen, please report this as a bug.",
+                '/images/facepalm.png',
+                true
+            ),
+            502: new ErrorPageProps(
+                'Under Construction',
+                "Sorry, looks like that content isn't available yet. Check again later.",
+                '/images/sad.png'
+            )
+        }[code] || defaultPage
+    );
+}

--- a/src/lib/types/dates.ts
+++ b/src/lib/types/dates.ts
@@ -1,4 +1,0 @@
-export type Dates = {
-    start: string;
-    end?: string;
-};

--- a/src/lib/types/file.ts
+++ b/src/lib/types/file.ts
@@ -1,5 +1,0 @@
-export type File = {
-    metadata: object;
-    default: any;
-    slug?: string;
-};

--- a/src/lib/types/image.ts
+++ b/src/lib/types/image.ts
@@ -1,4 +1,0 @@
-export type Image = {
-    src: string;
-    alt: string;
-};

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,4 +1,0 @@
-export * from './dates';
-export * from './file';
-export * from './image';
-export * from './links';

--- a/src/lib/types/links.ts
+++ b/src/lib/types/links.ts
@@ -1,9 +1,0 @@
-export type Links = {
-    devpost: string;
-    discord: string;
-    github: string;
-    instagram: string;
-    linkedin: string;
-    orcid: string;
-    website: string;
-};

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -5,5 +5,3 @@ export function isDevelopment(): boolean {
 
     return process.env.NODE_ENV.toLowerCase() === 'development';
 }
-
-export * from '../types/dates';

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -9,47 +9,56 @@
 		400: { // Bad Request
 			title: "PEBCAK Error",
             message: "You've sent an invalid request. What do you expect me to do with that?",
-            emote: "/images/facepalm.png"
+            emote: "/images/facepalm.png",
+            bugBtn: true
         },
 		401: { // Unauthorized
 			title: "Halt! You got a license for that?",
             message: "You need to authenticate before you can access this page.",
-            emote: "/images/thinking.png"
+            emote: "/images/thinking.png",
+            bugBtn: true
         },
         403: { // Forbidden
 			title: "Missing Permissions",
             message: "Sorry pal, looks like you can't access that content.",
-            emote: "/images/facepalm.png"
+            emote: "/images/facepalm.png",
+            bugBtn: true
         },
 		404: { // Not Found
 			title: "Page Not Found",
             message: "Looks like the page you've requested doesn't exist.",
-            emote: "/images/thinking.png"
+            emote: "/images/thinking.png",
+            bugBtn: true
         },
         418: { // I'm a Teapot
 			title: "Woah! Crazy Easter Egg!",
             message: "I'm a little teapot, short and stout. Here is my handle, here is my spout. When I get all steamed up, hear me shout 'Tip me over and pour me out!'",
-            emote: "/images/tea.png"
+            emote: "/images/tea.png",
+            bugBtn: false
         },
         429: { // Too Many Requests
 			title: "You've Been Ratelimited!",
             message: "Stop, you've violated the ratelimit policy! Pay the Court a fine or serve your sentence!",
             emote: "/images/anger.png",
+            bugBtn: false
         },
         451: { // Unavailable for Legal Reasons
 			title: "For Legal Reasons this Content is Unavailable",
             message: "Move along, move along, nothing to see here. Please allow this button to guide you back home.",
-            emote: "/images/thinking.png"
+            emote: "/images/thinking.png",
+            bugBtn: false
         },
         500: { // Internal Server Error
 			title: "Stop, hammer time!",
             message: "Something's broken. Very broken. An error like this shouldn't happen, please report this as a bug.",
-            emote: "/images/facepalm.png"
+            emote: "/images/facepalm.png",
+            bugBtn: true
         },
         501: { // Not Implemented
 			title: "Under Construction",
             message: "Sorry, looks like that content isn't available yet. Check again later.",
-            emote: "/images/sad.png"
+            emote: "/images/sad.png",
+            bugBtn: false
         }
     };
 </script>
@@ -77,12 +86,14 @@
                     </a>
                 </button>
 
-                <button>
-                    <a class="max-lg:block rounded-lg p-4 bg-red-500 hover:bg-red-700 transition duration-200 shadow-md" href="https://github.com/Jack-Gledhill/jackgledhill.com/issues/new">
-                        <FontAwesomeIcon icon={faGithub} fixedWidth />
-                        Report a bug
-                    </a>
-                </button>
+                {#if (errors[page.status].bugBtn)}
+                    <button>
+                        <a class="max-lg:block rounded-lg p-4 bg-red-500 hover:bg-red-700 transition duration-200 shadow-md" href="https://github.com/Jack-Gledhill/jackgledhill.com/issues/new">
+                            <FontAwesomeIcon icon={faGithub} fixedWidth />
+                            Report a bug
+                        </a>
+                    </button>
+                {/if}
             </div>
         </div>
     </div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,66 +1,17 @@
-<script>
+<script lang="ts">
 	import { page } from '$app/state';
+    import { getErrorPageProps } from '$lib/errors';
 
     import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
     import { faGithub } from '@fortawesome/free-brands-svg-icons';
     import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 
-	const errors = {
-		400: { // Bad Request
-			title: "PEBCAK Error",
-            message: "You've sent an invalid request. What do you expect me to do with that?",
-            emote: "/images/facepalm.png",
-            bugBtn: true
-        },
-		401: { // Unauthorized
-			title: "Halt! You got a license for that?",
-            message: "You need to authenticate before you can access this page.",
-            emote: "/images/thinking.png",
-            bugBtn: true
-        },
-        403: { // Forbidden
-			title: "Missing Permissions",
-            message: "Sorry pal, looks like you can't access that content.",
-            emote: "/images/facepalm.png",
-            bugBtn: true
-        },
-		404: { // Not Found
-			title: "Page Not Found",
-            message: "Looks like the page you've requested doesn't exist.",
-            emote: "/images/thinking.png",
-            bugBtn: true
-        },
-        418: { // I'm a Teapot
-			title: "Woah! Crazy Easter Egg!",
-            message: "I'm a little teapot, short and stout. Here is my handle, here is my spout. When I get all steamed up, hear me shout 'Tip me over and pour me out!'",
-            emote: "/images/tea.png",
-            bugBtn: false
-        },
-        429: { // Too Many Requests
-			title: "You've Been Ratelimited!",
-            message: "Stop, you've violated the ratelimit policy! Pay the Court a fine or serve your sentence!",
-            emote: "/images/anger.png",
-            bugBtn: false
-        },
-        451: { // Unavailable for Legal Reasons
-			title: "For Legal Reasons this Content is Unavailable",
-            message: "Move along, move along, nothing to see here. Please allow this button to guide you back home.",
-            emote: "/images/thinking.png",
-            bugBtn: false
-        },
-        500: { // Internal Server Error
-			title: "Stop, hammer time!",
-            message: "Something's broken. Very broken. An error like this shouldn't happen, please report this as a bug.",
-            emote: "/images/facepalm.png",
-            bugBtn: true
-        },
-        501: { // Not Implemented
-			title: "Under Construction",
-            message: "Sorry, looks like that content isn't available yet. Check again later.",
-            emote: "/images/sad.png",
-            bugBtn: false
-        }
-    };
+	const {
+        title,
+        message,
+        emote,
+        bugBtn
+    } = getErrorPageProps(page.status);
 </script>
 
 <svelte:head>
@@ -70,13 +21,13 @@
 <div class="min-h-screen p-8 lg:px-48 text-center flex flex-col justify-center">
     <div class="grid lg:grid-cols-3 gap-16 items-center">
         <div class="rounded-full mx-auto max-lg:w-3/4 bg-slate-800 border-10  border-slate-600">
-            <img class="rounded-b-full" src={errors[page.status].emote} alt="Decorative emoji in Jack's likeness" />
+            <img class="rounded-b-full" src={emote} alt="Decorative emoji in Jack's likeness" />
         </div>
 
         <div class="lg:col-span-2 flex flex-col gap-8">
             <h1 class="text-8xl font-bold">{page.status}</h1>
-            <h2 class="text-4xl font-bold">{errors[page.status].title}</h2>
-            <p class="text-xl">{errors[page.status].message}</p>
+            <h2 class="text-4xl font-bold">{title}</h2>
+            <p class="text-xl">{message}</p>
 
             <div class="flex flex-col lg:flex-row gap-8 justify-center">
                 <button>
@@ -86,7 +37,7 @@
                     </a>
                 </button>
 
-                {#if (errors[page.status].bugBtn)}
+                {#if (bugBtn)}
                     <button>
                         <a class="max-lg:block rounded-lg p-4 bg-red-500 hover:bg-red-700 transition duration-200 shadow-md" href="https://github.com/Jack-Gledhill/jackgledhill.com/issues/new">
                             <FontAwesomeIcon icon={faGithub} fixedWidth />


### PR DESCRIPTION
All this PR really does is create a new lib file called `errors.ts` that contains a function mapping a HTTP status code to a class of error properties. Should the error code not be configured, a default set of props is returned instead.