### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -8,33 +8,51 @@ article h3,
 article h4,
 article h5,
 article h6 {
-    @apply font-bold capitalize;
+    @apply font-bold;
+    @apply capitalize;
 }
 
 article h1 {
-    @apply text-4xl leading-20 text-center;
+    @apply text-center;
+    @apply text-4xl lg:text-6xl;
+    @apply leading-12 lg:leading-20;
 }
 
 article h2 {
-    @apply text-2xl leading-20;
+    @apply text-2xl;
+    @apply leading-12 lg:leading-20;
 }
 
 article h3 {
-    @apply text-xl leading-16;
+    @apply text-xl;
+    @apply lg:leading-16;
 }
 
 article > p {
-    @apply text-justify my-4;
+    @apply text-justify;
+    @apply my-4;
 }
 
 article a {
-    @apply hover:text-slate-400 underline;
+    @apply hover:text-slate-400;
+    @apply underline;
+}
+
+article ol,
+article ul {
+    @apply list-inside;
 }
 
 article ol {
-    @apply list-decimal list-inside;
+    @apply list-decimal;
 }
 
 article ul {
-    @apply list-disc list-inside;
+    @apply list-disc;
+}
+
+article hr {
+    @apply border-slate-600;
+    @apply my-8;
+    @apply lg:mx-16;
 }

--- a/src/content/pages/copyright.md
+++ b/src/content/pages/copyright.md
@@ -4,6 +4,10 @@ title: Copyright & Attributions
 description: A list of attributions for the various logos and icons used on this website.
 ---
 
+# Copyright & Attributions
+
+---
+
 The Kubernetes logo is copyright &copy; 2025 The Linux Foundation and reproduced here under the [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/) license.
 
 The ShefESH logo is copyright &copy; 2018 Sheffield Ethical Student Hackers and is reproduced here under [Section 30 of the Copyright, Designs and Patents Act 1988](https://www.legislation.gov.uk/ukpga/1988/48/section/30).

--- a/src/routes/(home)/+layout.svelte
+++ b/src/routes/(home)/+layout.svelte
@@ -11,7 +11,7 @@
 
     <Navbar />
 
-    <div class="w-full bg-slate-800 rounded-b-lg lg:rounded-tr-lg border-1 border-slate-700 p-8 flex flex-col gap-8">
+    <div class="w-full bg-slate-800 border-1 border-slate-700 rounded-b-lg lg:rounded-tr-lg p-4 lg:p-8">
         {@render children()}
     </div>
 </div>

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -73,7 +73,7 @@
 {#snippet card(meta: CardMetadata, content: Mdsvex.Renderer)}
     {#if !meta.draft || env.isDev}
         <div class="bg-slate-700 border-1 border-slate-600 rounded-xl p-4">
-            <div class="grid grid-cols-4 lg:grid-cols-5 gap-8">
+            <div class="grid grid-cols-4 md:grid-cols-5 gap-8">
                 <div class="col-span-4 flex flex-col gap-2">
                     {#if meta.draft}
                         <div>
@@ -121,7 +121,7 @@
                 </div>
 
                 {#if meta.logo}
-                    <div class="hidden lg:block">
+                    <div class="hidden md:block">
                         <img class="rounded-lg 2xl:rounded-2xl" src={meta.logo.src} alt={meta.logo.alt} />
                     </div>
                 {/if}

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -21,7 +21,7 @@
     let { data } = $props();
 </script>
 
-<div class="grid lg:grid-cols-2 2xl:grid-cols-3 gap-8">
+<div class="grid lg:grid-cols-2 2xl:grid-cols-3 gap-4 lg:gap-8">
     {#if page.url.hash === "#events"}
         {#each data.events as e (e.title)}
             {@render card({
@@ -132,13 +132,15 @@
             <div class="flex flex-col gap-4">
                 {@render content?.()}
 
-                <div class="flex flex-row flex-wrap gap-2 text-sm">
-                    {#each meta.tags as t (t)}
-                        <div class="bg-slate-800 rounded-full px-3 py-1">
-                            {t}
-                        </div>
-                    {/each}
-                </div>
+                {#if meta.tags}
+                    <div class="flex flex-row flex-wrap gap-2 text-sm">
+                        {#each meta.tags as t (t)}
+                            <div class="bg-slate-800 rounded-full px-3 py-1">
+                                {t}
+                            </div>
+                        {/each}
+                    </div>
+                {/if}
             </div>
         </div>
     {/if}

--- a/src/routes/(home)/+page.svelte
+++ b/src/routes/(home)/+page.svelte
@@ -73,7 +73,7 @@
 {#snippet card(meta: CardMetadata, content: Mdsvex.Renderer)}
     {#if !meta.draft || env.isDev}
         <div class="bg-slate-700 border-1 border-slate-600 rounded-xl p-4">
-            <div class="grid grid-cols-5 gap-8">
+            <div class="grid grid-cols-4 lg:grid-cols-5 gap-8">
                 <div class="col-span-4 flex flex-col gap-2">
                     {#if meta.draft}
                         <div>
@@ -121,7 +121,7 @@
                 </div>
 
                 {#if meta.logo}
-                    <div class="col-span-1">
+                    <div class="hidden lg:block">
                         <img class="rounded-lg 2xl:rounded-2xl" src={meta.logo.src} alt={meta.logo.alt} />
                     </div>
                 {/if}

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -4,20 +4,15 @@
 	import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
     import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 
-    import { page } from '$app/state';
     let { children } = $props();
 </script>
 
-<div class="p-8 md:p-12 border-b-1 border-slate-600 bg-slate-800">
-    <a href="/">
+<div class="p-8 md:px-72 md:py-12 flex flex-col gap-4">
+    <a class="text-center lg:text-left" href="/">
         <FontAwesomeIcon icon={faArrowLeft} fixedWidth />
         <span class="underline hover:text-slate-400">Back home</span>
     </a>
 
-    <h1 class="font-bold text-4xl leading-20 text-center">{page.data.metadata.title}</h1>
-</div>
-
-<div class="py-8 md:px-72 md:py-12">
     <article>
         {@render children()}
     </article>

--- a/src/routes/(pages)/+layout.svelte
+++ b/src/routes/(pages)/+layout.svelte
@@ -7,8 +7,8 @@
     let { children } = $props();
 </script>
 
-<div class="p-8 md:px-72 md:py-12 flex flex-col gap-4">
-    <a class="text-center lg:text-left" href="/">
+<div class="p-8 md:py-12 lg:px-72 flex flex-col gap-4">
+    <a class="text-center md:text-left" href="/">
         <FontAwesomeIcon icon={faArrowLeft} fixedWidth />
         <span class="underline hover:text-slate-400">Back home</span>
     </a>


### PR DESCRIPTION
## Changelog

- Reduce card gutters on mobile and tablet
- Hide image on cards on mobile
- Fix gutter for basic page template on mobile and tablet
- Redesign basic page template s.t. title is given by a h1 tag in page content
- Make back home button on basic page template centered on mobile
- Add styles for basic page template for hr tags
- Modify basic page template styles for h1 to replicate the removed title