### PR TITLE
Fix FontAwesome icons appearing massive on first load

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import '../app.css';
+    import '@fortawesome/fontawesome-svg-core/styles.css';
+    import { config } from '@fortawesome/fontawesome-svg-core';
     import { Head } from '$lib/components';
+
+    config.autoAddCss = false;
 
     import { page } from '$app/state';
 	let { children } = $props();


### PR DESCRIPTION
This appears to be an issue with FontAwesome's SVGs loading in before the CSS does. The fix is to just load the CSS ourselves at the root of the page.