### PR TITLE
Update end dates for societies and add in CompSoc 2026/27

### DIFF
--- a/src/content/committees/compsoc_24.md
+++ b/src/content/committees/compsoc_24.md
@@ -1,6 +1,6 @@
 ---
 draft: false
-title: CompSoc
+title: CompSoc 2024/25
 position: First Year Representative
 date:
   start: 2024-10-01

--- a/src/content/committees/compsoc_26.md
+++ b/src/content/committees/compsoc_26.md
@@ -1,0 +1,17 @@
+---
+draft: false
+title: CompSoc 2026/27
+position: Tech Officer
+date:
+  start: 2026-04-29
+logo: societies/compsoc
+links:
+  discord: 3e9GMgc
+  github: shefcompsoc
+  instagram: shefcompsoc
+  linkedin: shefcompsoc
+  website: shefcompsoc.uk
+---
+
+Sheffield CompSoc is the University of Sheffield's Computer Science society, providing a platform for students to engage with technology, collaborate on projects, and participate in events.
+As Tech Officer, I am responsible for the society's technical resources, including all the tech needs of HackSheffield 11.

--- a/src/content/committees/shefesh.md
+++ b/src/content/committees/shefesh.md
@@ -4,6 +4,7 @@ title: ShefESH
 position: Inclusions Officer
 date:
   start: 2025-03-01
+  end: 2026-04-20
 logo: societies/shefesh
 links:
   discord: rhfnwgphdx

--- a/src/content/committees/slugsoc.md
+++ b/src/content/committees/slugsoc.md
@@ -4,6 +4,7 @@ title: SLUGSoc
 position: Technical Officer
 date:
   start: 2025-03-01
+  end: 2026-04-28
 logo: societies/slugsoc
 links:
   discord: VvUCXCT

--- a/src/lib/mdsvex/index.ts
+++ b/src/lib/mdsvex/index.ts
@@ -1,5 +1,5 @@
 export function getSlug(path: string): string {
-    return path.split('/').at(-1)?.replace('.md', '') || '';
+    return path.split('/').at(-1)?.replace('.md', '') || path.replace('.md', '');
 }
 
 export function resolveFiles(files: Record<string, unknown>): Mdsvex.Entry[] {

--- a/src/lib/site.config.ts
+++ b/src/lib/site.config.ts
@@ -60,7 +60,7 @@ export const hero: Config.Hero = {
     image: portraits.gencem,
     socials: {
         github: 'Jack-Gledhill',
-        linkedin: 'LinkedIn',
+        linkedin: 'jackgledhill',
         orcid: '0009-0000-3055-0714'
     },
     positions: [
@@ -75,7 +75,7 @@ export const hero: Config.Hero = {
             href: 'https://sheffield.ac.uk'
         }
     ]
-}
+};
 
 export const footer: Config.Footer = {
     wordmark: emblem.wordmark


### PR DESCRIPTION
This PR:
- Adds end dates to SLUGSoc and ShefESH committees
- Fixes a typo in LinkedIn username for main page
- Adds a committee card for CompSoc 2026/27
- Fixes a bug where getSlug for paths without a separator returns an empty string